### PR TITLE
Users and roles now linked up correctly.

### DIFF
--- a/OpenIDConnect.Host/OpenIDConnect.Host.csproj
+++ b/OpenIDConnect.Host/OpenIDConnect.Host.csproj
@@ -71,6 +71,10 @@
     <Reference Include="IdentityAdmin">
       <HintPath>..\packages\IdentityServer3.Admin.1.0.0-beta4\IdentityAdmin.dll</HintPath>
     </Reference>
+    <Reference Include="IdentityManager, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>bin\IdentityManager.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.AspNet.Identity.Core, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.AspNet.Identity.Core.2.2.1\lib\net45\Microsoft.AspNet.Identity.Core.dll</HintPath>
       <Private>True</Private>

--- a/OpenIDConnect.Host/Startup.cs
+++ b/OpenIDConnect.Host/Startup.cs
@@ -7,6 +7,7 @@ using OpenIDConnect.IdentityManager;
 using OpenIDConnect.IdentityAdmin;
 using OpenIDConnect.IdentityServer;
 
+
 [assembly: OwinStartup(typeof(OpenIDConnect.Host.Startup))]
 
 namespace OpenIDConnect.Host
@@ -42,6 +43,30 @@ namespace OpenIDConnect.Host
                 {
                     scope.Resolve<IdentityManagerBootstrapper>().Run(manageApp);
                 });
+                //app.Map("/memory", memoryApp =>
+                //{
+               // using IdentityManager;
+               // using IdentityManager.Configuration;
+               // using System.Collections.Generic;
+
+                //    var factory = new IdentityManagerServiceFactory
+                //    {
+
+                //    };
+
+                //    var rand = new System.Random();
+                //    var users = new List<InMemoryUser>();
+                //    var roles = new List<InMemoryRole>();
+
+                //    factory.Register(new Registration<ICollection<InMemoryUser>>(users));
+                //    factory.Register(new Registration<ICollection<InMemoryRole>>(roles));
+                //    factory.IdentityManagerService = new Registration<IIdentityManagerService, InMemoryIdentityManagerService>();
+
+                //    memoryApp.UseIdentityManager(new IdentityManagerOptions
+                //    {
+                //        Factory = factory,
+                //    });
+                //});
             }
         }
     }

--- a/OpenIDConnect.IdentityServer.AspNet/Model/RoleManager.cs
+++ b/OpenIDConnect.IdentityServer.AspNet/Model/RoleManager.cs
@@ -26,7 +26,10 @@ namespace OpenIDConnect.IdentityServer.AspNet.Model
                 results = results.Where(u => u.Name.Contains(filter)).ToList();
             }
             int total = results.Count();
-            results = results.Skip(start).Take(count).ToList();
+            if (start >= 0 && count >= 0)
+            {
+                results = results.Skip(start).Take(count).ToList();
+            }
             return new QueryResult<Role>(start, count, total, null, results);
         }
 

--- a/OpenIDConnect.IdentityServer.AspNet/Model/UserManager.cs
+++ b/OpenIDConnect.IdentityServer.AspNet/Model/UserManager.cs
@@ -112,7 +112,8 @@ namespace OpenIDConnect.IdentityServer.AspNet.Model
                 var newRoles = roles.Where(r => !existingRoles.Contains(r.Value));
                 foreach (var role in newRoles)
                 {
-                    this.AddToRole(userID, role.Value);
+                    this.AddToRole(userID, role.Value); //This one adds an entry to the userroles table
+                    this.AddClaim(userID, role); //This one adds a claim, which seems to be the one actually used
                 }
             }
             return claims;
@@ -152,7 +153,10 @@ namespace OpenIDConnect.IdentityServer.AspNet.Model
             }
 
             int total = results.Count();
-            results = results.Skip(start).Take(count).ToList();
+            if (count >= 0 && start >= 0)
+            {
+                results = results.Skip(start).Take(count).ToList();
+            }
            
             return new QueryResult<User>(start, count, total, null, results);
         }


### PR DESCRIPTION
There is some odd duplication in this area:
The inbuilt IdentityUsers and IdentityRoles came with a AspNetUserRoles table, but in the Identity Manager it is purely the claims of type role that are displayed. So....I've wired up both, a new user role will both appear in the User Claims and in the UserRoles tables.